### PR TITLE
Allow for any .sb2 filename

### DIFF
--- a/cs50/2017/fall/scratch/check50/__init__.py
+++ b/cs50/2017/fall/scratch/check50/__init__.py
@@ -19,7 +19,7 @@ class Scratch(Checks):
             raise Error("No .sb2 file found.")
         filename = filenames[0]
 
-        # Ensure that unzipped .sb2 file contains .json file
+        # Ensure that unzipped .sb2 file contains .json file.
         self.spawn("unzip {}".format(shlex.quote(filename))).exit()
         self.require("project.json")
 

--- a/cs50/2017/fall/scratch/check50/__init__.py
+++ b/cs50/2017/fall/scratch/check50/__init__.py
@@ -1,4 +1,7 @@
 import json
+import os
+import shlex
+
 from check50 import *
 
 
@@ -7,10 +10,17 @@ class Scratch(Checks):
     @check()
     def valid(self):
         """project exists and is valid Scratch program"""
-        self.require("project.sb2")
+
+        # Make sure there is only one .sb2 file.
+        filenames = list(filter(lambda filename: filename.endswith(".sb2"), os.listdir()))
+        if len(filenames) > 1:
+            raise Error("More than one .sb2 file found. Make sure there's only one!")
+        elif len(filenames) == 0:
+            raise Error("No .sb2 file found.")
+        filename = filenames[0]
 
         # Ensure that unzipped .sb2 file contains .json file
-        self.spawn("unzip project.sb2").exit()
+        self.spawn("unzip {}".format(shlex.quote(filename))).exit()
         self.require("project.json")
 
     @check("valid")


### PR DESCRIPTION
Currently, the Scratch checks require that the filename be `project.sb2`. Now, checks will pass so long as is one and only one `.sb2` file in the repo, regardless of filename. If there are no `.sb2` files, or if there are more than one, checks will fail.