### PR TITLE
fix ciphertext issue

### DIFF
--- a/cs50/2019/spring/caesar/check50/__init__.py
+++ b/cs50/2019/spring/caesar/check50/__init__.py
@@ -16,32 +16,32 @@ class Caesar(Checks):
     @check("compiles")
     def encrypts_a_as_b(self):
         """encrypts "a" as "b" using 1 as key"""
-        self.spawn("./caesar 1").stdin("a").stdout("ciphertext:\s*b\n", "ciphertext: b\n").exit(0)
+        self.spawn("./caesar 1").stdin("a").stdout("[Cc]iphertext:\s*b\n", "ciphertext: b\n").exit(0)
 
     @check("compiles")
     def encrypts_barfoo_as_yxocll(self):
         """encrypts "barfoo" as "yxocll" using 23 as key"""
-        self.spawn("./caesar 23").stdin("barfoo").stdout("ciphertext:\s*yxocll\n", "ciphertext: yxocll\n").exit(0)
+        self.spawn("./caesar 23").stdin("barfoo").stdout("[Cc]iphertext:\s*yxocll\n", "ciphertext: yxocll\n").exit(0)
 
     @check("compiles")
     def encrypts_BARFOO_as_EDUIRR(self):
         """encrypts "BARFOO" as "EDUIRR" using 3 as key"""
-        self.spawn("./caesar 3").stdin("BARFOO").stdout("ciphertext:\s*EDUIRR\n", "ciphertext: EDUIRR\n").exit(0)
+        self.spawn("./caesar 3").stdin("BARFOO").stdout("[Cc]iphertext:\s*EDUIRR\n", "ciphertext: EDUIRR\n").exit(0)
 
     @check("compiles")
     def encrypts_BaRFoo_FeVJss(self):
         """encrypts "BaRFoo" as "FeVJss" using 4 as key"""
-        self.spawn("./caesar 4").stdin("BaRFoo").stdout("ciphertext:\s*FeVJss\n", "ciphertext: FeVJss\n").exit(0)
+        self.spawn("./caesar 4").stdin("BaRFoo").stdout("[Cc]iphertext:\s*FeVJss\n", "ciphertext: FeVJss\n").exit(0)
 
     @check("compiles")
     def encrypts_barfoo_as_onesbb(self):
         """encrypts "barfoo" as "onesbb" using 65 as key"""
-        self.spawn("./caesar 65").stdin("barfoo").stdout("ciphertext:\s*onesbb\n", "ciphertext: onesbb\n").exit(0)
+        self.spawn("./caesar 65").stdin("barfoo").stdout("[Cc]iphertext:\s*onesbb\n", "ciphertext: onesbb\n").exit(0)
 
     @check("compiles")
     def checks_for_handling_non_alpha(self):
         """encrypts "world, say hello!" as "iadxp, emk tqxxa!" using 12 as key"""
-        self.spawn("./caesar 12").stdin("world, say hello!").stdout("ciphertext:\s*iadxp, emk tqxxa!\n", "ciphertext: iadxp, emk tqxxa!\n").exit(0)
+        self.spawn("./caesar 12").stdin("world, say hello!").stdout("[Cc]iphertext:\s*iadxp, emk tqxxa!\n", "ciphertext: iadxp, emk tqxxa!\n").exit(0)
 
     @check("compiles")
     def handles_no_argv(self):

--- a/cs50/2019/spring/vigenere/check50/__init__.py
+++ b/cs50/2019/spring/vigenere/check50/__init__.py
@@ -16,32 +16,32 @@ class Vigenere(Checks):
     @check("compiles")
     def aa(self):
         """encrypts "a" as "a" using "a" as keyword"""
-        self.spawn("./vigenere a").stdin("a").stdout("ciphertext:\s*a\n", "ciphertext: a\n").exit(0)
+        self.spawn("./vigenere a").stdin("a").stdout("[Cc]iphertext:\s*a\n", "ciphertext: a\n").exit(0)
 
     @check("compiles")
     def bazbarfoo_caqgon(self):
         """encrypts "barfoo" as "caqgon" using "baz" as keyword"""
-        self.spawn("./vigenere baz").stdin("barfoo").stdout("ciphertext:\s*caqgon\n", "ciphertext: caqgon\n").exit(0)
+        self.spawn("./vigenere baz").stdin("barfoo").stdout("[Cc]iphertext:\s*caqgon\n", "ciphertext: caqgon\n").exit(0)
 
     @check("compiles")
     def mixedBaZBARFOO(self):
         """encrypts "BaRFoo" as "CaQGon" using "BaZ" as keyword"""
-        self.spawn("./vigenere BaZ").stdin("BaRFoo").stdout("ciphertext:\s*CaQGon\n", "ciphertext: CaQGon\n").exit(0)
+        self.spawn("./vigenere BaZ").stdin("BaRFoo").stdout("[Cc]iphertext:\s*CaQGon\n", "ciphertext: CaQGon\n").exit(0)
 
     @check("compiles")
     def allcapsBAZBARFOO(self):
         """encrypts "BARFOO" as "CAQGON" using "BAZ" as keyword"""
-        self.spawn("./vigenere BAZ").stdin("BARFOO").stdout("ciphertext:\s*CAQGON\n", "ciphertext: CAQGON\n").exit(0)
+        self.spawn("./vigenere BAZ").stdin("BARFOO").stdout("[Cc]iphertext:\s*CAQGON\n", "ciphertext: CAQGON\n").exit(0)
 
     @check("compiles")
     def bazworld(self):
         """encrypts "world!$?" as "xoqmd!$?" using "baz" as keyword"""
-        self.spawn("./vigenere baz").stdin("world!$?").stdout("ciphertext:\s*xoqmd!\$\?\n", "ciphertext: xoqmd!$?\n").exit(0)
+        self.spawn("./vigenere baz").stdin("world!$?").stdout("[Cc]iphertext:\s*xoqmd!\$\?\n", "ciphertext: xoqmd!$?\n").exit(0)
 
     @check("compiles")
     def withspaces(self):
         """encrypts "hello, world!" as "iekmo, vprke!" using "baz" as keyword"""
-        self.spawn("./vigenere baz").stdin("hello, world!").stdout("ciphertext:\s*iekmo, vprke!\n", "ciphertext: iekmo, vprke!\n").exit(0)
+        self.spawn("./vigenere baz").stdin("hello, world!").stdout("[Cc]iphertext:\s*iekmo, vprke!\n", "ciphertext: iekmo, vprke!\n").exit(0)
 
     @check("compiles")
     def noarg(self):

--- a/cs50/2019/x/caesar/check50/__init__.py
+++ b/cs50/2019/x/caesar/check50/__init__.py
@@ -16,32 +16,32 @@ class Caesar(Checks):
     @check("compiles")
     def encrypts_a_as_b(self):
         """encrypts "a" as "b" using 1 as key"""
-        self.spawn("./caesar 1").stdin("a").stdout("ciphertext:\s*b\n", "ciphertext: b\n").exit(0)
+        self.spawn("./caesar 1").stdin("a").stdout("[Cc]iphertext:\s*b\n", "ciphertext: b\n").exit(0)
 
     @check("compiles")
     def encrypts_barfoo_as_yxocll(self):
         """encrypts "barfoo" as "yxocll" using 23 as key"""
-        self.spawn("./caesar 23").stdin("barfoo").stdout("ciphertext:\s*yxocll\n", "ciphertext: yxocll\n").exit(0)
+        self.spawn("./caesar 23").stdin("barfoo").stdout("[Cc]iphertext:\s*yxocll\n", "ciphertext: yxocll\n").exit(0)
 
     @check("compiles")
     def encrypts_BARFOO_as_EDUIRR(self):
         """encrypts "BARFOO" as "EDUIRR" using 3 as key"""
-        self.spawn("./caesar 3").stdin("BARFOO").stdout("ciphertext:\s*EDUIRR\n", "ciphertext: EDUIRR\n").exit(0)
+        self.spawn("./caesar 3").stdin("BARFOO").stdout("[Cc]iphertext:\s*EDUIRR\n", "ciphertext: EDUIRR\n").exit(0)
 
     @check("compiles")
     def encrypts_BaRFoo_FeVJss(self):
         """encrypts "BaRFoo" as "FeVJss" using 4 as key"""
-        self.spawn("./caesar 4").stdin("BaRFoo").stdout("ciphertext:\s*FeVJss\n", "ciphertext: FeVJss\n").exit(0)
+        self.spawn("./caesar 4").stdin("BaRFoo").stdout("[Cc]iphertext:\s*FeVJss\n", "ciphertext: FeVJss\n").exit(0)
 
     @check("compiles")
     def encrypts_barfoo_as_onesbb(self):
         """encrypts "barfoo" as "onesbb" using 65 as key"""
-        self.spawn("./caesar 65").stdin("barfoo").stdout("ciphertext:\s*onesbb\n", "ciphertext: onesbb\n").exit(0)
+        self.spawn("./caesar 65").stdin("barfoo").stdout("[Cc]iphertext:\s*onesbb\n", "ciphertext: onesbb\n").exit(0)
 
     @check("compiles")
     def checks_for_handling_non_alpha(self):
         """encrypts "world, say hello!" as "iadxp, emk tqxxa!" using 12 as key"""
-        self.spawn("./caesar 12").stdin("world, say hello!").stdout("ciphertext:\s*iadxp, emk tqxxa!\n", "ciphertext: iadxp, emk tqxxa!\n").exit(0)
+        self.spawn("./caesar 12").stdin("world, say hello!").stdout("[Cc]iphertext:\s*iadxp, emk tqxxa!\n", "ciphertext: iadxp, emk tqxxa!\n").exit(0)
 
     @check("compiles")
     def handles_no_argv(self):

--- a/cs50/2019/x/vigenere/check50/__init__.py
+++ b/cs50/2019/x/vigenere/check50/__init__.py
@@ -16,32 +16,32 @@ class Vigenere(Checks):
     @check("compiles")
     def aa(self):
         """encrypts "a" as "a" using "a" as keyword"""
-        self.spawn("./vigenere a").stdin("a").stdout("ciphertext:\s*a\n", "ciphertext: a\n").exit(0)
+        self.spawn("./vigenere a").stdin("a").stdout("[Cc]iphertext:\s*a\n", "ciphertext: a\n").exit(0)
 
     @check("compiles")
     def bazbarfoo_caqgon(self):
         """encrypts "barfoo" as "caqgon" using "baz" as keyword"""
-        self.spawn("./vigenere baz").stdin("barfoo").stdout("ciphertext:\s*caqgon\n", "ciphertext: caqgon\n").exit(0)
+        self.spawn("./vigenere baz").stdin("barfoo").stdout("[Cc]iphertext:\s*caqgon\n", "ciphertext: caqgon\n").exit(0)
 
     @check("compiles")
     def mixedBaZBARFOO(self):
         """encrypts "BaRFoo" as "CaQGon" using "BaZ" as keyword"""
-        self.spawn("./vigenere BaZ").stdin("BaRFoo").stdout("ciphertext:\s*CaQGon\n", "ciphertext: CaQGon\n").exit(0)
+        self.spawn("./vigenere BaZ").stdin("BaRFoo").stdout("[Cc]iphertext:\s*CaQGon\n", "ciphertext: CaQGon\n").exit(0)
 
     @check("compiles")
     def allcapsBAZBARFOO(self):
         """encrypts "BARFOO" as "CAQGON" using "BAZ" as keyword"""
-        self.spawn("./vigenere BAZ").stdin("BARFOO").stdout("ciphertext:\s*CAQGON\n", "ciphertext: CAQGON\n").exit(0)
+        self.spawn("./vigenere BAZ").stdin("BARFOO").stdout("[Cc]iphertext:\s*CAQGON\n", "ciphertext: CAQGON\n").exit(0)
 
     @check("compiles")
     def bazworld(self):
         """encrypts "world!$?" as "xoqmd!$?" using "baz" as keyword"""
-        self.spawn("./vigenere baz").stdin("world!$?").stdout("ciphertext:\s*xoqmd!\$\?\n", "ciphertext: xoqmd!$?\n").exit(0)
+        self.spawn("./vigenere baz").stdin("world!$?").stdout("[Cc]iphertext:\s*xoqmd!\$\?\n", "ciphertext: xoqmd!$?\n").exit(0)
 
     @check("compiles")
     def withspaces(self):
         """encrypts "hello, world!" as "iekmo, vprke!" using "baz" as keyword"""
-        self.spawn("./vigenere baz").stdin("hello, world!").stdout("ciphertext:\s*iekmo, vprke!\n", "ciphertext: iekmo, vprke!\n").exit(0)
+        self.spawn("./vigenere baz").stdin("hello, world!").stdout("[Cc]iphertext:\s*iekmo, vprke!\n", "ciphertext: iekmo, vprke!\n").exit(0)
 
     @check("compiles")
     def noarg(self):


### PR DESCRIPTION
Students often lose correctness points in the autograder because some capitalize `Ciphertext` instead, which is often corrected manually. This should resolve that particular issue. Could generalize entirely to any text string, but feels reasonable to be consistent with spec expectations.