### PR TITLE
Make lookup case insensitive

### DIFF
--- a/cs50/2019/x/finance/check50/lookup.py
+++ b/cs50/2019/x/finance/check50/lookup.py
@@ -1,9 +1,9 @@
 def lookup(symbol):
-    if (symbol == "AAAA"):
+    if (symbol.upper() == "AAAA"):
         return {"name": "Stock A", "price": 28.00, "symbol": "AAAA"}
-    elif (symbol == "BBBB"):
+    elif (symbol.upper() == "BBBB"):
         return {"name": "Stock B", "price": 14.00, "symbol": "BBBB"}
-    elif (symbol == "CCCC"):
+    elif (symbol.upper() == "CCCC"):
         return {"name": "Stock C", "price": 2000.00, "symbol": "CCCC"}
     else:
         return None


### PR DESCRIPTION
The live API from IEX is case insensitive, while check50s lookup is not. When preprocessing data provided by the user this leads to errors reported from check50 which are not present in a live instance. Transforming the input using .upper() more closely emulates the behaviour of IEX.