### PR TITLE
update vigenere check to use python3

### DIFF
--- a/cs50/2019/x/sentimental/vigenere/check50/__init__.py
+++ b/cs50/2019/x/sentimental/vigenere/check50/__init__.py
@@ -36,7 +36,7 @@ class Vigenere(Checks):
     @check("exists")
     def withspaces(self):
         """encrypts "hello, world!" as "iekmo, vprke!" using "baz" as keyword"""
-        self.spawn("python vigenere.py baz").stdin("hello, world!").stdout("ciphertext:\s*iekmo, vprke!\n", "ciphertext: iekmo, vprke!\n").exit(0)
+        self.spawn("python3 vigenere.py baz").stdin("hello, world!").stdout("ciphertext:\s*iekmo, vprke!\n", "ciphertext: iekmo, vprke!\n").exit(0)
 
     @check("exists")
     def noarg(self):


### PR DESCRIPTION
The check was just `python` unlike all the others, and `check50` was returning errors for that test because `python` defaults to python2?